### PR TITLE
Fix approve_all staging check

### DIFF
--- a/src/songripper/worker.py
+++ b/src/songripper/worker.py
@@ -61,5 +61,9 @@ def rip_playlist(pl_url: str):
     return "done"
 
 def approve_all():
-    for p in (DATA_DIR / "staging").iterdir():
+    staging = DATA_DIR / "staging"
+    # Staging may be missing if no playlists were ripped yet
+    if not staging.exists() or not any(staging.iterdir()):
+        return
+    for p in staging.iterdir():
         shutil.move(str(p), NAS_PATH / p.name)


### PR DESCRIPTION
## Summary
- handle missing or empty `staging` dir in `approve_all`

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement yt-dlp)*
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f88689990832ca33270f921312b90