### PR TITLE
Set container restart policy to unless-stopped

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
 
   watchtower:
     image: containrrr/watchtower:latest
+    restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     env_file:


### PR DESCRIPTION
## Summary
- ensure both `songripper` and `watchtower` restart automatically unless stopped manually

## Testing
- `docker-compose config` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685420d47a8c832cb9f94c154ad72d59