### PR TITLE
Add watchtower scope label

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ WATCHTOWER_TELEGRAM_TOKEN=<bot token>
 WATCHTOWER_TELEGRAM_CHAT_ID=<chat id>
 ```
 
+Watchtower is scoped to containers labelled `com.centurylinklabs.watchtower.scope=songripper`.
+This label is added to the `songripper` service so only it is updated.
+
 Remove or comment out the `watchtower` block if you don't wish to use automatic
 updates.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,9 @@ version: "3.9"
 
 services:
   songripper:
-    build: .
     image: ghcr.io/rudyscoggins/songripper:latest
+    labels:
+      - com.centurylinklabs.watchtower.scope=songripper
     restart: unless-stopped
     environment:
       DATA_DIR: /data


### PR DESCRIPTION
## Summary
- label `songripper` container for watchtower
- remove the local build so compose always uses the GHCR image
- explain watchtower scope in the docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685479076c58832c860a8318c82cc6dc