### PR TITLE
Add delete staging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ music collection.
 docker compose up --build
 ```
 
-The web UI allows you to submit a YouTube playlist URL and to approve all staged tracks.
+The web UI allows you to submit a YouTube playlist URL, approve all staged tracks
+or delete the staging area.
 
 ## Environment Variables
 

--- a/src/songripper/api.py
+++ b/src/songripper/api.py
@@ -2,7 +2,7 @@
 from fastapi import FastAPI, Request, Form, BackgroundTasks
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
-from .worker import rip_playlist, approve_all
+from .worker import rip_playlist, approve_all, delete_staging
 app = FastAPI()
 templates = Jinja2Templates(directory="src/songripper/templates")
 
@@ -18,4 +18,9 @@ def rip(playlist_url: str = Form(...), bg: BackgroundTasks = None):
 @app.post("/approve")
 def approve():
     approve_all()
+    return RedirectResponse("/", status_code=303)
+
+@app.post("/delete")
+def delete():
+    delete_staging()
     return RedirectResponse("/", status_code=303)

--- a/src/songripper/templates/index.html
+++ b/src/songripper/templates/index.html
@@ -16,6 +16,9 @@
 <form hx-post="/approve" hx-swap="none">
   <button type="submit">Approve & Move All</button>
 </form>
+<form hx-post="/delete" hx-swap="none">
+  <button type="submit">Unapprove and Delete Staging</button>
+</form>
 <p>Staged files live in <code>./data/staging/</code> until you approve.</p>
 </body>
 </html>

--- a/src/songripper/worker.py
+++ b/src/songripper/worker.py
@@ -78,3 +78,8 @@ def approve_all():
         return
     for p in staging.iterdir():
         shutil.move(str(p), NAS_PATH / p.name)
+
+def delete_staging():
+    staging = DATA_DIR / "staging"
+    if staging.exists():
+        shutil.rmtree(staging)


### PR DESCRIPTION
## Summary
- add `delete_staging` helper to remove ./data/staging
- expose `/delete` endpoint for clearing staging
- show new 'Unapprove and Delete Staging' button in web UI
- document the option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6854b746b29c832caf35460073e2f306