### PR TITLE
Add delete confirmation message

### DIFF
--- a/src/songripper/api.py
+++ b/src/songripper/api.py
@@ -7,8 +7,9 @@ app = FastAPI()
 templates = Jinja2Templates(directory="src/songripper/templates")
 
 @app.get("/", response_class=HTMLResponse)
-def home(req: Request):
-    return templates.TemplateResponse("index.html", {"request": req})
+def home(req: Request, msg: str | None = None):
+    context = {"request": req, "message": msg}
+    return templates.TemplateResponse("index.html", context)
 
 @app.post("/rip")
 def rip(playlist_url: str = Form(...), bg: BackgroundTasks = None):
@@ -23,4 +24,4 @@ def approve():
 @app.post("/delete")
 def delete():
     delete_staging()
-    return RedirectResponse("/", status_code=303)
+    return RedirectResponse("/?msg=Files+successfully+deleted", status_code=303)

--- a/src/songripper/templates/index.html
+++ b/src/songripper/templates/index.html
@@ -3,9 +3,12 @@
 <head>
   <meta charset="utf-8">
   <title>Song Ripper</title>
-  <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+<script src="https://unpkg.com/htmx.org@1.9.10"></script>
 </head>
 <body>
+{% if message %}
+<p style="color: green;">{{ message }}</p>
+{% endif %}
 <h2>Rip YouTube Playlist</h2>
 <form hx-post="/rip" hx-swap="none">
   <input type="text" name="playlist_url" placeholder="https://www.youtube.com/playlist?list=..." size="80" required>


### PR DESCRIPTION
## Summary
- show optional messages on home page
- display message when staging area is deleted

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6854bd249130832c8793195a964faa80