### PR TITLE
Add basic unit tests

### DIFF
--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,29 @@
+import types
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from songripper.worker import clean, fetch_cover
+
+
+def test_clean_removes_forbidden_chars():
+    text = 'A/B:C*D?E"F<G>H|I'
+    assert clean(text) == 'A_B_C_D_E_F_G_H_I'
+
+
+def test_fetch_cover_uses_requests_module():
+    calls = []
+    def fake_get(url, params=None, timeout=None):
+        calls.append((url, params))
+        class Resp:
+            def __init__(self):
+                self.content = b"img"
+            def json(self):
+                return {"results": [{"artworkUrl100": "http://x/100x100bb"}]}
+            def raise_for_status(self):
+                pass
+        return Resp()
+    fake_requests = types.SimpleNamespace(get=fake_get)
+    result = fetch_cover("a", "b", fake_requests)
+    assert result == b"img"
+    assert calls[0][0] == "https://itunes.apple.com/search"
+    assert calls[1][0] == "http://x/600x600bb"


### PR DESCRIPTION
## Summary
- make `worker` functions import optional dependencies lazily
- add `requests_mod` argument to `fetch_cover`
- create tests for the `clean` and `fetch_cover` helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854be3bffc4832c86cd818a074fd872