### PR TITLE
Add deletion prompt

### DIFF
--- a/src/songripper/api.py
+++ b/src/songripper/api.py
@@ -31,4 +31,4 @@ def approve():
 @app.post("/delete")
 def delete():
     delete_staging()
-    return RedirectResponse("/?msg=Files+successfully+deleted", status_code=303)
+    return RedirectResponse("/?msg=Files+deleted", status_code=303)

--- a/src/songripper/static/main.js
+++ b/src/songripper/static/main.js
@@ -1,1 +1,9 @@
 console.log('loaded');
+
+document.addEventListener('DOMContentLoaded', function () {
+  const params = new URLSearchParams(window.location.search);
+  const msg = params.get('msg');
+  if (msg) {
+    alert(msg.replace(/\+/g, ' '));
+  }
+});

--- a/src/songripper/templates/index.html
+++ b/src/songripper/templates/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 {% if message %}
-<p style="color: green;">{{ message }}</p>
+<p id="message" style="color: green;">{{ message }}</p>
 {% endif %}
 <h2>Rip YouTube Playlist</h2>
 <form hx-post="/rip" hx-swap="none">


### PR DESCRIPTION
## Summary
- add deletion prompt to front-end
- surface message in API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854c810dbb4832cadea5faa3c03957b