### PR TITLE
Show message when staging empty

### DIFF
--- a/src/songripper/api.py
+++ b/src/songripper/api.py
@@ -30,5 +30,8 @@ def approve():
 
 @app.post("/delete")
 def delete():
-    delete_staging()
-    return RedirectResponse("/?msg=Files+deleted", status_code=303)
+    if delete_staging():
+        msg = "Files+deleted"
+    else:
+        msg = "No+files+in+staging"
+    return RedirectResponse(f"/?msg={msg}", status_code=303)

--- a/src/songripper/worker.py
+++ b/src/songripper/worker.py
@@ -94,7 +94,14 @@ def approve_all():
     for p in staging.iterdir():
         shutil.move(str(p), NAS_PATH / p.name)
 
-def delete_staging():
+def delete_staging() -> bool:
+    """Delete the staging directory if it contains files.
+
+    Returns ``True`` if any files were removed, otherwise ``False``.
+    ``False`` is returned when the directory does not exist or is empty.
+    """
     staging = DATA_DIR / "staging"
-    if staging.exists():
-        shutil.rmtree(staging)
+    if not staging.exists() or not any(staging.iterdir()):
+        return False
+    shutil.rmtree(staging)
+    return True

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2,7 +2,8 @@ import types
 import os
 import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
-from songripper.worker import clean, fetch_cover
+from songripper import worker
+from songripper.worker import clean, fetch_cover, delete_staging
 
 
 def test_clean_removes_forbidden_chars():
@@ -27,3 +28,17 @@ def test_fetch_cover_uses_requests_module():
     assert result == b"img"
     assert calls[0][0] == "https://itunes.apple.com/search"
     assert calls[1][0] == "http://x/600x600bb"
+
+
+def test_delete_staging_returns_false_when_no_files(tmp_path):
+    worker.DATA_DIR = tmp_path
+    assert delete_staging() is False
+
+
+def test_delete_staging_removes_dir_and_returns_true(tmp_path):
+    worker.DATA_DIR = tmp_path
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    (staging / "a").write_text("x")
+    assert delete_staging() is True
+    assert not staging.exists()


### PR DESCRIPTION
## Summary
- make `delete_staging` report whether anything was removed
- show `No files in staging` when delete endpoint has nothing to remove
- test new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68552a61a24c832c916f0f53dda3ac4f