### PR TITLE
Add footer with package update time

### DIFF
--- a/src/songripper/__init__.py
+++ b/src/songripper/__init__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pathlib import Path
+from datetime import datetime, timezone
+
+PACKAGE_TIME = datetime.fromtimestamp(
+    Path(__file__).stat().st_mtime,
+    timezone.utc,
+).isoformat(timespec="seconds")
+
+__all__ = ["PACKAGE_TIME"]

--- a/src/songripper/api.py
+++ b/src/songripper/api.py
@@ -5,6 +5,7 @@ from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
 from .worker import rip_playlist, approve_all, delete_staging
 from .settings import CACHE_BUSTER
+from . import PACKAGE_TIME
 app = FastAPI()
 app.mount("/static", StaticFiles(directory="src/songripper/static"), name="static")
 templates = Jinja2Templates(directory="src/songripper/templates")
@@ -15,6 +16,7 @@ def home(req: Request, msg: str | None = None):
         "request": req,
         "message": msg,
         "v": CACHE_BUSTER,
+        "updated": PACKAGE_TIME,
     }
     return templates.TemplateResponse("index.html", context)
 

--- a/src/songripper/static/styles.css
+++ b/src/songripper/static/styles.css
@@ -1,1 +1,7 @@
 body {}
+
+footer {
+  margin-top: 2em;
+  font-size: 0.9em;
+  color: #666;
+}

--- a/src/songripper/templates/index.html
+++ b/src/songripper/templates/index.html
@@ -25,5 +25,6 @@
   <button type="submit">Unapprove and Delete Staging</button>
 </form>
 <p>Staged files live in <code>./data/staging/</code> until you approve.</p>
+<footer>Last package update: {{ updated }}</footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose `PACKAGE_TIME` from `songripper` and show it in web UI
- display update timestamp in site footer
- style footer element

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68552f4932ec832c9781e8ecee316c50