### PR TITLE
Display update timestamp in US Central time

### DIFF
--- a/src/songripper/__init__.py
+++ b/src/songripper/__init__.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-from datetime import datetime, timezone
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 PACKAGE_TIME = datetime.fromtimestamp(
     Path(__file__).stat().st_mtime,
-    timezone.utc,
+    tz=ZoneInfo("America/Chicago"),
 ).isoformat(timespec="seconds")
 
 __all__ = ["PACKAGE_TIME"]


### PR DESCRIPTION
## Summary
- use `ZoneInfo("America/Chicago")` for PACKAGE_TIME

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68555d68aca4832c9cb77e126d874ab8