### PR TITLE
Improve spacing between approval buttons

### DIFF
--- a/src/songripper/static/styles.css
+++ b/src/songripper/static/styles.css
@@ -1,5 +1,9 @@
 body {}
 
+.approval-actions form {
+  margin-bottom: 1em;
+}
+
 footer {
   margin-top: 2em;
   font-size: 0.9em;

--- a/src/songripper/templates/index.html
+++ b/src/songripper/templates/index.html
@@ -18,12 +18,14 @@
 </form>
 
 <h3>Approve staged tracks</h3>
-<form hx-post="/approve" hx-swap="none">
-  <button type="submit">Approve & Move All</button>
-</form>
-<form action="/delete" method="post">
-  <button type="submit">Unapprove and Delete Staging</button>
-</form>
+<div class="approval-actions">
+  <form hx-post="/approve" hx-swap="none">
+    <button type="submit">Approve & Move All</button>
+  </form>
+  <form action="/delete" method="post">
+    <button type="submit">Unapprove and Delete Staging</button>
+  </form>
+</div>
 <p>Staged files live in <code>./data/staging/</code> until you approve.</p>
 <footer>Last package update: {{ updated }}</footer>
 </body>


### PR DESCRIPTION
## Summary
- wrap approve/unapprove forms in container
- apply CSS spacing to forms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855b7221ec0832c91d3253435697453