### PR TITLE
Add no-cache middleware

### DIFF
--- a/src/songripper/api.py
+++ b/src/songripper/api.py
@@ -7,6 +7,15 @@ from .worker import rip_playlist, approve_all, delete_staging
 from .settings import CACHE_BUSTER
 from . import PACKAGE_TIME
 app = FastAPI()
+
+@app.middleware("http")
+async def add_no_cache_headers(request: Request, call_next):
+    response = await call_next(request)
+    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
+    return response
+
 app.mount("/static", StaticFiles(directory="src/songripper/static"), name="static")
 templates = Jinja2Templates(directory="src/songripper/templates")
 


### PR DESCRIPTION
## Summary
- disable browser caching for all FastAPI responses by adding middleware

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856989ceb0c832c862879b87dcdfeb1