### PR TITLE
Use HTMX for delete feedback with fade-out alerts

### DIFF
--- a/src/songripper/api.py
+++ b/src/songripper/api.py
@@ -40,9 +40,12 @@ def approve():
     return RedirectResponse("/", status_code=303)
 
 @app.post("/delete")
-def delete():
+def delete(request: Request):
     if delete_staging():
-        msg = "Files+deleted"
+        msg = "Files deleted"
     else:
-        msg = "No+files+in+staging"
-    return RedirectResponse(f"/?msg={msg}", status_code=303)
+        msg = "No files in staging"
+    if request.headers.get("Hx-Request"):
+        context = {"request": request, "message": msg}
+        return templates.TemplateResponse("message.html", context)
+    return RedirectResponse(f"/?msg={msg.replace(' ', '+')}", status_code=303)

--- a/src/songripper/static/main.js
+++ b/src/songripper/static/main.js
@@ -1,9 +1,20 @@
 console.log('loaded');
 
+function fadeOutAlerts(container) {
+  if (container && container.innerHTML.trim() !== '') {
+    setTimeout(() => {
+      container.innerHTML = '';
+    }, 4000);
+  }
+}
+
 document.addEventListener('DOMContentLoaded', function () {
-  const params = new URLSearchParams(window.location.search);
-  const msg = params.get('msg');
-  if (msg) {
-    alert(msg.replace(/\+/g, ' '));
+  const alerts = document.getElementById('alerts');
+  fadeOutAlerts(alerts);
+});
+
+document.addEventListener('htmx:afterSwap', function (evt) {
+  if (evt.target.id === 'alerts') {
+    fadeOutAlerts(evt.target);
   }
 });

--- a/src/songripper/templates/index.html
+++ b/src/songripper/templates/index.html
@@ -8,9 +8,11 @@
   <script src="https://unpkg.com/htmx.org@1.9.10"></script>
 </head>
 <body>
+<div id="alerts">
 {% if message %}
-<p id="message" style="color: green;">{{ message }}</p>
+  <p id="message" style="color: green;">{{ message }}</p>
 {% endif %}
+</div>
 <h2>Rip YouTube Playlist</h2>
 <form hx-post="/rip" hx-swap="none">
   <input type="text" name="playlist_url" placeholder="https://www.youtube.com/playlist?list=..." size="80" required>
@@ -22,7 +24,7 @@
   <form hx-post="/approve" hx-swap="none">
     <button type="submit">Approve & Move All</button>
   </form>
-  <form action="/delete" method="post">
+  <form hx-post="/delete" hx-target="#alerts" hx-swap="innerHTML">
     <button type="submit">Unapprove and Delete Staging</button>
   </form>
 </div>

--- a/src/songripper/templates/message.html
+++ b/src/songripper/templates/message.html
@@ -1,0 +1,1 @@
+<p id="message" style="color: green;">{{ message }}</p>


### PR DESCRIPTION
## Summary
- add `alerts` container to home template
- use HTMX to post delete and target alerts
- add new `message.html` template
- update `/delete` endpoint to return fragment to HTMX
- implement fading alerts in `main.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856983740e8832c9cb51c397c846504