### PR TITLE
Disable approve button when staging empty

### DIFF
--- a/src/songripper/api.py
+++ b/src/songripper/api.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI, Request, Form, BackgroundTasks
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
-from .worker import rip_playlist, approve_all, delete_staging
+from .worker import rip_playlist, approve_all, delete_staging, staging_has_files
 from .settings import CACHE_BUSTER
 from . import PACKAGE_TIME
 app = FastAPI()
@@ -26,6 +26,7 @@ def home(req: Request, msg: str | None = None):
         "message": msg,
         "v": CACHE_BUSTER,
         "updated": PACKAGE_TIME,
+        "has_staged_files": staging_has_files(),
     }
     return templates.TemplateResponse("index.html", context)
 

--- a/src/songripper/templates/index.html
+++ b/src/songripper/templates/index.html
@@ -22,7 +22,7 @@
 <h3>Approve staged tracks</h3>
 <div class="approval-actions">
   <form hx-post="/approve" hx-swap="none">
-    <button type="submit">Approve & Move All</button>
+    <button type="submit"{% if not has_staged_files %} disabled{% endif %}>Approve & Move All</button>
   </form>
   <form hx-post="/delete" hx-target="#alerts" hx-swap="innerHTML">
     <button type="submit">Unapprove and Delete Staging</button>

--- a/src/songripper/worker.py
+++ b/src/songripper/worker.py
@@ -86,10 +86,15 @@ def rip_playlist(pl_url: str):
     print("Songs successfully transferred to staging directory")
     return "done"
 
+def staging_has_files() -> bool:
+    """Return True if staging directory exists and is non-empty."""
+    staging = DATA_DIR / "staging"
+    return staging.exists() and any(staging.iterdir())
+
 def approve_all():
     staging = DATA_DIR / "staging"
     # Staging may be missing if no playlists were ripped yet
-    if not staging.exists() or not any(staging.iterdir()):
+    if not staging_has_files():
         return
     for p in staging.iterdir():
         shutil.move(str(p), NAS_PATH / p.name)
@@ -101,7 +106,7 @@ def delete_staging() -> bool:
     ``False`` is returned when the directory does not exist or is empty.
     """
     staging = DATA_DIR / "staging"
-    if not staging.exists() or not any(staging.iterdir()):
+    if not staging_has_files():
         return False
     shutil.rmtree(staging)
     return True

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -102,3 +102,15 @@ def test_rip_playlist_moves_files(monkeypatch, tmp_path):
         (str(tmp_path / "song2.mp3"), dest2),
     ]
     assert result == "done"
+
+
+def test_staging_has_files(tmp_path):
+    worker.DATA_DIR = tmp_path
+    # No staging dir -> False
+    assert worker.staging_has_files() is False
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    # Empty dir -> False
+    assert worker.staging_has_files() is False
+    (staging / "song.mp3").write_text("x")
+    assert worker.staging_has_files() is True


### PR DESCRIPTION
## Summary
- disable the "Approve & Move All" button when no staged files are present
- expose helper `staging_has_files` in worker
- use helper in API and worker
- cover helper with unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856a094a9a8832caf0a86ffbf271b2f