### PR TITLE
Add ripping spinner and staging refresh

### DIFF
--- a/src/songripper/api.py
+++ b/src/songripper/api.py
@@ -1,5 +1,5 @@
 # src/songripper/api.py
-from fastapi import FastAPI, Request, Form, BackgroundTasks
+from fastapi import FastAPI, Request, Form
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
@@ -37,8 +37,10 @@ def home(req: Request, msg: str | None = None):
     return templates.TemplateResponse("index.html", context)
 
 @app.post("/rip")
-def rip(playlist_url: str = Form(...), bg: BackgroundTasks = None):
-    bg.add_task(rip_playlist, playlist_url)
+def rip(request: Request, playlist_url: str = Form(...)):
+    rip_playlist(playlist_url)
+    if request.headers.get("Hx-Request"):
+        return HTMLResponse("", status_code=204, headers={"HX-Trigger": "refreshStaging"})
     return RedirectResponse("/", status_code=303)
 
 @app.post("/approve")

--- a/src/songripper/static/styles.css
+++ b/src/songripper/static/styles.css
@@ -9,3 +9,22 @@ footer {
   font-size: 0.9em;
   color: #666;
 }
+
+#spinner {
+  display: none;
+  width: 16px;
+  height: 16px;
+  border: 2px solid #ccc;
+  border-top-color: #333;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-left: 0.5em;
+}
+
+#spinner.htmx-request {
+  display: inline-block;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/src/songripper/templates/index.html
+++ b/src/songripper/templates/index.html
@@ -14,7 +14,8 @@
 {% endif %}
 </div>
 <h2>Rip YouTube Playlist</h2>
-<form hx-post="/rip" hx-swap="none">
+<div id="spinner" aria-hidden="true"></div>
+<form hx-post="/rip" hx-swap="none" hx-indicator="#spinner">
   <input type="text" name="playlist_url" placeholder="https://www.youtube.com/playlist?list=..." size="80" required>
   <button type="submit">Rip!</button>
 </form>


### PR DESCRIPTION
## Summary
- refresh staging table after ripping completes
- show a spinner during the rip request so users know it's running

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f3464878832c806323c459dce3c9