### PR TITLE
Update styling to lime on black

### DIFF
--- a/src/songripper/static/styles.css
+++ b/src/songripper/static/styles.css
@@ -3,6 +3,8 @@ body {
   margin: 1em auto;
   padding: 0 1em;
   max-width: 800px;
+  background-color: #000;
+  color: lime;
 }
 
 form {
@@ -49,7 +51,7 @@ th, td {
 footer {
   margin-top: 2em;
   font-size: 0.9em;
-  color: #666;
+  color: #9f9;
 }
 
 #spinner {

--- a/src/songripper/templates/index.html
+++ b/src/songripper/templates/index.html
@@ -11,7 +11,7 @@
 <body>
 <div id="alerts">
 {% if message %}
-  <p id="message" style="color: green;">{{ message }}</p>
+  <p id="message" style="color: lime;">{{ message }}</p>
 {% endif %}
 </div>
 <h2>Rip YouTube Playlist</h2>

--- a/src/songripper/templates/message.html
+++ b/src/songripper/templates/message.html
@@ -1,1 +1,1 @@
-<p id="message" style="color: green;">{{ message }}</p>
+<p id="message" style="color: lime;">{{ message }}</p>


### PR DESCRIPTION
## Summary
- set lime text on a black background
- update timestamp color
- adjust inline message styles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857f51f6330832c9ef9a1fc61038031