### PR TITLE
Display album art in staging view

### DIFF
--- a/src/songripper/models.py
+++ b/src/songripper/models.py
@@ -45,4 +45,7 @@ class Track(SQLModel, table=True):
     filepath: str
     id: Optional[int] = Field(default=None, primary_key=True)
     approved: bool = False
+    # base64 encoded album art from the MP3's ID3 tag.  May be ``None`` when
+    # no cover image is found or when tag parsing dependencies are missing.
+    cover: Optional[str] = None
 

--- a/src/songripper/static/styles.css
+++ b/src/songripper/static/styles.css
@@ -72,3 +72,9 @@ footer {
 @keyframes spin {
   to { transform: rotate(360deg); }
 }
+
+.album-art {
+  width: 50px;
+  height: 50px;
+  object-fit: cover;
+}

--- a/src/songripper/templates/staging.html
+++ b/src/songripper/templates/staging.html
@@ -1,6 +1,7 @@
 <table>
   <thead>
     <tr>
+      <th>Art</th>
       <th>Artist</th>
       <th>Album</th>
       <th>Title</th>
@@ -10,6 +11,13 @@
   <tbody>
   {% for track in tracks %}
     <tr>
+      <td>
+        {% if track.cover %}
+          <img src="{{ track.cover }}" alt="cover" class="album-art">
+        {% else %}
+          &mdash;
+        {% endif %}
+      </td>
       <td>{{ track.artist }}</td>
       <td>{{ track.album }}</td>
       <td>{{ track.title }}</td>

--- a/src/songripper/worker.py
+++ b/src/songripper/worker.py
@@ -132,6 +132,21 @@ def list_staged_tracks() -> list[Track]:
                     _, title = name.split(" - ", 1)
                 else:
                     title = name
+                cover_b64 = None
+                try:  # pragma: no cover - optional dependency
+                    from mutagen.id3 import ID3
+                    import base64
+                    tags = ID3(mp3)
+                    pics = tags.getall("APIC") if hasattr(tags, "getall") else []
+                    if pics:
+                        pic = pics[0]
+                        mime = getattr(pic, "mime", "image/jpeg")
+                        cover_b64 = "data:%s;base64,%s" % (
+                            mime,
+                            base64.b64encode(pic.data).decode("ascii"),
+                        )
+                except Exception:
+                    cover_b64 = None
                 tracks.append(
                     Track(
                         job_id=0,
@@ -139,6 +154,7 @@ def list_staged_tracks() -> list[Track]:
                         album=album_dir.name,
                         title=title,
                         filepath=str(mp3),
+                        cover=cover_b64,
                     )
                 )
 


### PR DESCRIPTION
## Summary
- include album art field on `Track`
- extract album art from ID3 tags when listing staged tracks
- show album art column in `staging.html`
- style album art images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857fb200290832c97f36ac20ca6d14f