### PR TITLE
Add border styling for popup messages

### DIFF
--- a/src/songripper/static/styles.css
+++ b/src/songripper/static/styles.css
@@ -44,6 +44,15 @@ th, td {
   z-index: 1000;
 }
 
+#alerts p {
+  color: lime;
+  border: 1px solid lime;
+  padding: 0.5em;
+  margin: 0;
+  background-color: #111;
+  border-radius: 4px;
+}
+
 .approval-actions form {
   margin-bottom: 1em;
 }

--- a/src/songripper/templates/index.html
+++ b/src/songripper/templates/index.html
@@ -11,7 +11,7 @@
 <body>
 <div id="alerts">
 {% if message %}
-  <p id="message" style="color: lime;">{{ message }}</p>
+  <p id="message">{{ message }}</p>
 {% endif %}
 </div>
 <h2>Rip YouTube Playlist</h2>

--- a/src/songripper/templates/message.html
+++ b/src/songripper/templates/message.html
@@ -1,1 +1,1 @@
-<p id="message" style="color: lime;">{{ message }}</p>
+<p id="message">{{ message }}</p>


### PR DESCRIPTION
## Summary
- style popup messages with a bordered box
- remove inline styles from templates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857fed00c28832cbda6f23a841a2fba