### PR TITLE
Add inline editing for staged tracks

### DIFF
--- a/src/songripper/templates/staging.html
+++ b/src/songripper/templates/staging.html
@@ -18,9 +18,9 @@
           &mdash;
         {% endif %}
       </td>
-      <td>{{ track.artist }}</td>
-      <td>{{ track.album }}</td>
-      <td>{{ track.title }}</td>
+      <td hx-get="/edit?filepath={{ track.filepath }}&field=artist" hx-trigger="click" hx-target="this" hx-swap="outerHTML">{{ track.artist }}</td>
+      <td hx-get="/edit?filepath={{ track.filepath }}&field=album" hx-trigger="click" hx-target="this" hx-swap="outerHTML">{{ track.album }}</td>
+      <td hx-get="/edit?filepath={{ track.filepath }}&field=title" hx-trigger="click" hx-target="this" hx-swap="outerHTML">{{ track.title }}</td>
       <td>{{ track.filepath }}</td>
     </tr>
   {% endfor %}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,6 +27,11 @@ class FastAPI:
             return fn
         return deco
 
+    def put(self, *args, **kwargs):
+        def deco(fn):
+            return fn
+        return deco
+
 fastapi.FastAPI = FastAPI
 fastapi.Form = lambda *a, **kw: None
 class Request:


### PR DESCRIPTION
## Summary
- allow editing of artist/album/title from the staging table
- update `worker` with helpers to read and update tags
- expose `/edit` endpoints in API for HTMX requests
- adjust API tests for new `put` decorator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68581a428304832ca48b914143f98429