### PR TITLE
Update approval button state based on staging list

### DIFF
--- a/src/songripper/static/main.js
+++ b/src/songripper/static/main.js
@@ -11,10 +11,21 @@ function fadeOutAlerts(container) {
 document.addEventListener('DOMContentLoaded', function () {
   const alerts = document.getElementById('alerts');
   fadeOutAlerts(alerts);
+  updateApprovalButton();
 });
 
 document.addEventListener('htmx:afterSwap', function (evt) {
   if (evt.target.id === 'alerts') {
     fadeOutAlerts(evt.target);
   }
+  if (evt.target.id === 'staging-list') {
+    updateApprovalButton();
+  }
 });
+
+function updateApprovalButton() {
+  const btn = document.getElementById('approve-btn');
+  if (!btn) return;
+  const hasTracks = document.querySelector('#staging-list tbody tr') !== null;
+  btn.disabled = !hasTracks;
+}

--- a/src/songripper/templates/index.html
+++ b/src/songripper/templates/index.html
@@ -24,7 +24,7 @@
 <h3>Approve staged tracks</h3>
 <div class="approval-actions">
   <form hx-post="/approve" hx-swap="none">
-    <button type="submit"{% if not has_staged_files %} disabled{% endif %}>Approve & Move All</button>
+    <button id="approve-btn" type="submit"{% if not has_staged_files %} disabled{% endif %}>Approve & Move All</button>
   </form>
     <form hx-post="/delete" hx-target="#alerts" hx-swap="innerHTML">
       <button type="submit">Unapprove and Delete Staging</button>


### PR DESCRIPTION
## Summary
- enable/disble the Approve button dynamically after the staging list loads
- add an id to the approve button for JS to toggle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68594a3969b8832c9512f654af7e5d07