### PR TITLE
Fix staging list refresh after ripping

### DIFF
--- a/src/songripper/templates/index.html
+++ b/src/songripper/templates/index.html
@@ -16,7 +16,8 @@
 </div>
 <h2>Rip YouTube Playlist</h2>
 <div id="spinner" aria-hidden="true"></div>
-<form hx-post="/rip" hx-swap="none" hx-indicator="#spinner">
+<form hx-post="/rip" hx-swap="none" hx-indicator="#spinner"
+      hx-on:afterRequest="document.body.dispatchEvent(new Event('refreshStaging'))">
   <input type="text" name="playlist_url" placeholder="https://www.youtube.com/playlist?list=..." required>
   <button type="submit">Rip!</button>
 </form>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -108,3 +108,10 @@ def test_delete_non_hx_redirect(monkeypatch):
     resp = api.delete(req)
     assert resp.status_code == 303
     assert resp.headers["location"] == "/?msg=Files+deleted"
+
+
+def test_rip_form_has_afterrequest_handler():
+    template_path = os.path.join(os.path.dirname(__file__), "..", "src", "songripper", "templates", "index.html")
+    with open(template_path) as fh:
+        html = fh.read()
+    assert "hx-on:afterRequest" in html


### PR DESCRIPTION
## Summary
- trigger a body refresh event after the ripping request finishes
- verify the afterRequest handler exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859624dd5cc832c96c4e90c440cc948