### PR TITLE
Improve editing without htmx

### DIFF
--- a/src/songripper/static/main.js
+++ b/src/songripper/static/main.js
@@ -23,6 +23,40 @@ document.addEventListener('htmx:afterSwap', function (evt) {
   }
 });
 
+if (!window.htmx) {
+  // Minimal fallback so inline editing works when the CDN script fails to load
+  document.addEventListener('DOMContentLoaded', function () {
+    document.body.addEventListener('click', function (e) {
+      const td = e.target.closest('td[hx-get][hx-trigger="click"]');
+      if (!td) return;
+      fetch(td.getAttribute('hx-get'))
+        .then(r => r.text())
+        .then(html => {
+          td.outerHTML = html;
+        });
+    });
+
+    document.body.addEventListener('keydown', function (e) {
+      if (e.key !== 'Enter') return;
+      const input = e.target;
+      if (!(input instanceof HTMLInputElement)) return;
+      const form = input.form;
+      if (!form || !form.hasAttribute('hx-put')) return;
+      e.preventDefault();
+      const data = new FormData(form);
+      fetch(form.getAttribute('hx-put'), {
+        method: 'PUT',
+        body: data
+      })
+        .then(r => r.text())
+        .then(html => {
+          const td = form.closest('td');
+          if (td) td.outerHTML = html;
+        });
+    });
+  });
+}
+
 function updateApprovalButton() {
   const btn = document.getElementById('approve-btn');
   if (!btn) return;


### PR DESCRIPTION
## Summary
- add fallback editing logic when the htmx CDN fails to load

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b04fe81c0832c95537922c1c7f735