### PR TITLE
Fix editing fields with invalid characters

### DIFF
--- a/src/songripper/worker.py
+++ b/src/songripper/worker.py
@@ -231,6 +231,7 @@ def update_track(filepath: str, field: str, value: str) -> Path:
     The file is renamed and moved inside the staging directory to match
     the updated artist/album/title structure.  Returns the new path.
     """
+    value = clean(value)
     tags = read_tags(filepath)
     tags[field] = value
     try:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -199,3 +199,16 @@ def test_mp3_from_url_embeds_thumbnail_when_no_itunes(monkeypatch, tmp_path):
     assert isinstance(id3_objects[0]["APIC"], DummyAPIC)
     assert id3_objects[0]["APIC"].kw["data"] == b"thumb"
     assert path == tmp_path / f"{artist_clean} - {title_clean}.mp3"
+
+
+def test_update_track_sanitizes_new_value(tmp_path):
+    worker.DATA_DIR = tmp_path
+    staging = tmp_path / "staging" / "Artist" / "Album"
+    staging.mkdir(parents=True)
+    track = staging / "Artist - Song.mp3"
+    track.write_text("x")
+
+    new_path = worker.update_track(str(track), "artist", "AC/DC")
+
+    assert new_path.name == "AC_DC - Song.mp3"
+    assert new_path.exists()


### PR DESCRIPTION
## Summary
- sanitize user-provided values when editing tracks
- add regression test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b66bbb7d8832ca3656ae112ef1d79