### PR TITLE
Handle missing files on edit

### DIFF
--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -212,3 +212,10 @@ def test_update_track_sanitizes_new_value(tmp_path):
 
     assert new_path.name == "AC_DC - Song.mp3"
     assert new_path.exists()
+
+
+def test_update_track_missing_file_raises(tmp_path):
+    worker.DATA_DIR = tmp_path
+    missing = tmp_path / "staging" / "bad.mp3"
+    with pytest.raises(worker.TrackUpdateError):
+        worker.update_track(str(missing), "artist", "A")


### PR DESCRIPTION
## Summary
- raise a `TrackUpdateError` if `update_track` can't find or rename a file
- catch `TrackUpdateError` in API edit endpoints and return HTTP 400
- test error handling in `worker.update_track` and the API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b6c97bbcc832caa95d76dee443337