### PR TITLE
Update multi-edit interaction

### DIFF
--- a/src/songripper/templates/staging.html
+++ b/src/songripper/templates/staging.html
@@ -20,9 +20,9 @@
           &mdash;
         {% endif %}
       </td>
-      <td hx-get="/edit?filepath={{ track.filepath }}&field=artist" hx-trigger="click" hx-target="this" hx-swap="outerHTML">{{ track.artist }}</td>
-      <td hx-get="/edit?filepath={{ track.filepath }}&field=album" hx-trigger="click" hx-target="this" hx-swap="outerHTML">{{ track.album }}</td>
-      <td hx-get="/edit?filepath={{ track.filepath }}&field=title" hx-trigger="click" hx-target="this" hx-swap="outerHTML">{{ track.title }}</td>
+      <td data-field="artist" class="editable-field">{{ track.artist }}</td>
+      <td data-field="album" class="editable-field">{{ track.album }}</td>
+      <td data-field="title" class="editable-field">{{ track.title }}</td>
       <td>{{ track.filepath }}</td>
     </tr>
   {% endfor %}


### PR DESCRIPTION
## Summary
- remove HX inline editing from each track row
- update multi-edit section automatically when clicking a row value
- drop old JavaScript fallback for inline editing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4f170954832cb1dfbf3cc0c690a2