### PR TITLE
Scroll to edit section on cell click

### DIFF
--- a/src/songripper/static/main.js
+++ b/src/songripper/static/main.js
@@ -44,6 +44,7 @@ function fillMultiEditFromCell(e) {
   const checkbox = form.querySelector(`input[name="${field}_enable"]`);
   if (input) input.value = td.textContent.trim();
   if (checkbox) checkbox.checked = true;
+  form.scrollIntoView({behavior: 'smooth'});
   const row = td.closest('tr');
   if (row) {
     const trackBox = row.querySelector('input[name=track]');


### PR DESCRIPTION
## Summary
- update multi-edit fill handler to scroll to the form once a cell is tapped

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cacbc90ac832c9a7b9cd614f2cbc4