### PR TITLE
Use title-based naming for ripped MP3s

### DIFF
--- a/tests/test_mp3.py
+++ b/tests/test_mp3.py
@@ -80,11 +80,11 @@ def test_mp3_from_url(tmp_path, monkeypatch):
 
     assert artist == artist_clean
     assert album == album_clean
-    assert path == tmp_path / f"{artist_clean} - {title_clean}.mp3"
+    assert path == tmp_path / f"{title_clean}.mp3"
 
     expected_out = worker.YT_BASE + [
         "-x", "--audio-format", "mp3",
-        "-o", str(tmp_path / f"{artist_clean} - {title_clean}.%(ext)s"),
+        "-o", str(tmp_path / f"{title_clean}.%(ext)s"),
         "http://x",
     ]
     assert run_calls == [(expected_out, True)]
@@ -93,4 +93,4 @@ def test_mp3_from_url(tmp_path, monkeypatch):
         worker.YT_BASE + ["-J", "--no-playlist", "http://x"],
         True,
     )]
-    assert easy_paths == [tmp_path / f"{artist_clean} - {title_clean}.mp3"]
+    assert easy_paths == [tmp_path / f"{title_clean}.mp3"]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -120,10 +120,10 @@ def test_list_staged_tracks(tmp_path):
     worker.DATA_DIR = tmp_path
     staging = tmp_path / "staging"
     (staging / "Artist1" / "Album1").mkdir(parents=True)
-    f1 = staging / "Artist1" / "Album1" / "Artist1 - Song1.mp3"
+    f1 = staging / "Artist1" / "Album1" / "Song1.mp3"
     f1.write_text("x")
     (staging / "Artist2" / "Album2").mkdir(parents=True)
-    f2 = staging / "Artist2" / "Album2" / "Artist2 - Song2.mp3"
+    f2 = staging / "Artist2" / "Album2" / "Song2.mp3"
     f2.write_text("y")
 
     tracks = sorted(worker.list_staged_tracks(), key=lambda t: t.title)
@@ -198,19 +198,19 @@ def test_mp3_from_url_embeds_thumbnail_when_no_itunes(monkeypatch, tmp_path):
     assert thumb_calls == [meta["thumbnail"]]
     assert isinstance(id3_objects[0]["APIC"], DummyAPIC)
     assert id3_objects[0]["APIC"].kw["data"] == b"thumb"
-    assert path == tmp_path / f"{artist_clean} - {title_clean}.mp3"
+    assert path == tmp_path / f"{title_clean}.mp3"
 
 
 def test_update_track_sanitizes_new_value(tmp_path):
     worker.DATA_DIR = tmp_path
     staging = tmp_path / "staging" / "Artist" / "Album"
     staging.mkdir(parents=True)
-    track = staging / "Artist - Song.mp3"
+    track = staging / "Song.mp3"
     track.write_text("x")
 
     new_path = worker.update_track(str(track), "artist", "AC/DC")
 
-    assert new_path.name == "AC_DC - Song.mp3"
+    assert new_path.name == "Song.mp3"
     assert new_path.exists()
 
 
@@ -226,12 +226,12 @@ def test_update_track_moves_file_and_listing_updates(tmp_path):
 
     staging = tmp_path / "staging" / "OldArtist" / "OldAlbum"
     staging.mkdir(parents=True)
-    track = staging / "OldArtist - OldTitle.mp3"
+    track = staging / "OldTitle.mp3"
     track.write_text("x")
 
     # Update artist
     p1 = worker.update_track(str(track), "artist", "NewArtist")
-    assert p1 == tmp_path / "staging" / "NewArtist" / "OldAlbum" / "NewArtist - OldTitle.mp3"
+    assert p1 == tmp_path / "staging" / "NewArtist" / "OldAlbum" / "OldTitle.mp3"
     assert p1.exists()
     assert not track.exists()
     tr = worker.list_staged_tracks()
@@ -239,7 +239,7 @@ def test_update_track_moves_file_and_listing_updates(tmp_path):
 
     # Update album
     p2 = worker.update_track(str(p1), "album", "NewAlbum")
-    assert p2 == tmp_path / "staging" / "NewArtist" / "NewAlbum" / "NewArtist - OldTitle.mp3"
+    assert p2 == tmp_path / "staging" / "NewArtist" / "NewAlbum" / "OldTitle.mp3"
     assert p2.exists()
     assert not p1.exists()
     tr = worker.list_staged_tracks()
@@ -247,7 +247,7 @@ def test_update_track_moves_file_and_listing_updates(tmp_path):
 
     # Update title
     p3 = worker.update_track(str(p2), "title", "NewTitle")
-    assert p3 == tmp_path / "staging" / "NewArtist" / "NewAlbum" / "NewArtist - NewTitle.mp3"
+    assert p3 == tmp_path / "staging" / "NewArtist" / "NewAlbum" / "NewTitle.mp3"
     assert p3.exists()
     tr = worker.list_staged_tracks()
     assert [(t.artist, t.album, t.title) for t in tr] == [


### PR DESCRIPTION
## Summary
- drop artist prefix when naming mp3 files
- optionally prefix filename with two‑digit track number
- adjust tagging and track updates for new naming scheme
- update tests for revised filenames

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685caefedc3c832cb03fcd95b1b8c3ca