### PR TITLE
Show 'No tracks found' message in staging list

### DIFF
--- a/src/songripper/templates/staging.html
+++ b/src/songripper/templates/staging.html
@@ -1,3 +1,4 @@
+{% if tracks %}
 <table class="track-table">
   <thead>
     <tr>
@@ -42,3 +43,6 @@
     <input type="text" name="title_value"></div>
   <button type="submit">Edit Multiple</button>
 </form>
+{% else %}
+<p id="no-tracks">No tracks found</p>
+{% endif %}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -203,3 +203,13 @@ def test_staging_template_has_select_all_checkbox():
         html = fh.read()
     assert 'id="select-all"' in html
     assert "Select All" in html
+
+
+def test_staging_template_shows_no_tracks_message():
+    path = os.path.join(
+        os.path.dirname(__file__), "..", "src", "songripper", "templates", "staging.html"
+    )
+    with open(path) as fh:
+        html = fh.read()
+    assert "No tracks found" in html
+    assert 'id="no-tracks"' in html


### PR DESCRIPTION
## Summary
- show a placeholder message when there are no staged tracks
- add a regression test for the template message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cb306583c832cb88bdce49cdf5ec1