### PR TITLE
Update multi-edit label to Edit Track(s)

### DIFF
--- a/src/songripper/templates/staging.html
+++ b/src/songripper/templates/staging.html
@@ -41,7 +41,7 @@
   <div>
     <label><input type="checkbox" name="title_enable"> Title</label>
     <input type="text" name="title_value"></div>
-  <button type="submit">Edit Multiple</button>
+  <button type="submit">Edit Track(s)</button>
 </form>
 {% else %}
 <p id="no-tracks">No tracks found</p>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -191,7 +191,7 @@ def test_staging_template_has_multi_edit_form():
     )
     with open(path) as fh:
         html = fh.read()
-    assert "Edit Multiple" in html
+    assert "Edit Track(s)" in html
     assert "hx-post=\"/edit-multiple\"" in html
 
 


### PR DESCRIPTION
## Summary
- rename the multi-edit button from **Edit Multiple** to **Edit Track(s)**
- update unit test to match new button text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da6286a68832c8a3d3edd6a007ce4