### PR TITLE
Place approval buttons after edit form

### DIFF
--- a/src/songripper/templates/index.html
+++ b/src/songripper/templates/index.html
@@ -22,15 +22,6 @@
   <button type="submit">Rip!</button>
 </form>
 
-<h3>Approve staged tracks</h3>
-<div class="approval-actions">
-  <form hx-post="/approve" hx-swap="none">
-    <button id="approve-btn" type="submit"{% if not has_staged_files %} disabled{% endif %}>Approve & Move All</button>
-  </form>
-    <form hx-post="/delete" hx-target="#alerts" hx-swap="innerHTML">
-      <button type="submit">Unapprove and Delete Staging</button>
-    </form>
-</div>
 <p>Staged files live in <code>./data/staging/</code> until you approve.</p>
   <div id="staging-list" hx-get="/staging" hx-trigger="load, refreshStaging from:body"></div>
   <h3>How to Use</h3>

--- a/src/songripper/templates/staging.html
+++ b/src/songripper/templates/staging.html
@@ -46,3 +46,13 @@
 {% else %}
 <p id="no-tracks">No tracks found</p>
 {% endif %}
+
+<h3>Approve staged tracks</h3>
+<div class="approval-actions">
+  <form hx-post="/approve" hx-swap="none">
+    <button id="approve-btn" type="submit"{% if not tracks %} disabled{% endif %}>Approve & Move All</button>
+  </form>
+  <form hx-post="/delete" hx-target="#alerts" hx-swap="innerHTML">
+    <button type="submit">Unapprove and Delete Staging</button>
+  </form>
+</div>


### PR DESCRIPTION
## Summary
- rearrange approval buttons to reside inside staging template
- remove unused section from main index

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685da74c6e34832cbe30f9a52c904b96