### PR TITLE
Add green fieldset around multi-edit form

### DIFF
--- a/src/songripper/static/styles.css
+++ b/src/songripper/static/styles.css
@@ -97,3 +97,11 @@ footer {
 .track-table td {
   border: 1px solid #666;
 }
+
+/* Group box for edit fields */
+#multi-edit fieldset.edit-fields {
+  border: 1px solid lime;
+  padding: 0.5em;
+  margin-bottom: 1em;
+  border-radius: 4px;
+}

--- a/src/songripper/templates/staging.html
+++ b/src/songripper/templates/staging.html
@@ -32,15 +32,17 @@
 <form id="multi-edit" hx-post="/edit-multiple" hx-swap="none"
       hx-include="[name=track]:checked"
       hx-on:afterRequest="document.body.dispatchEvent(new Event('refreshStaging'))">
-  <div>
-    <label><input type="checkbox" name="artist_enable"> Artist</label>
-    <input type="text" name="artist_value"></div>
-  <div>
-    <label><input type="checkbox" name="album_enable"> Album</label>
-    <input type="text" name="album_value"></div>
-  <div>
-    <label><input type="checkbox" name="title_enable"> Title</label>
-    <input type="text" name="title_value"></div>
+  <fieldset class="edit-fields">
+    <div>
+      <label><input type="checkbox" name="artist_enable"> Artist</label>
+      <input type="text" name="artist_value"></div>
+    <div>
+      <label><input type="checkbox" name="album_enable"> Album</label>
+      <input type="text" name="album_value"></div>
+    <div>
+      <label><input type="checkbox" name="title_enable"> Title</label>
+      <input type="text" name="title_value"></div>
+  </fieldset>
   <button type="submit">Edit Track(s)</button>
 </form>
 {% else %}


### PR DESCRIPTION
## Summary
- put the three track edit fields inside a `fieldset`
- style the fieldset with lime border to match the site theme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da82ccf94832ca318034bb66732f1