### PR TITLE
Add bulk album art editing

### DIFF
--- a/src/songripper/templates/staging.html
+++ b/src/songripper/templates/staging.html
@@ -31,7 +31,8 @@
 </table>
 <form id="multi-edit" hx-post="/edit-multiple" hx-swap="none"
       hx-include="[name=track]:checked"
-      hx-on:afterRequest="document.body.dispatchEvent(new Event('refreshStaging'))">
+      hx-on:afterRequest="document.body.dispatchEvent(new Event('refreshStaging'))"
+      enctype="multipart/form-data">
   <fieldset class="edit-fields">
     <div>
       <label><input type="checkbox" name="artist_enable"> Artist</label>
@@ -42,6 +43,9 @@
     <div>
       <label><input type="checkbox" name="title_enable"> Title</label>
       <input type="text" name="title_value"></div>
+    <div>
+      <label><input type="checkbox" name="art_enable"> Album Art</label>
+      <input type="file" name="art_file" accept="image/*"></div>
   </fieldset>
   <button type="submit">Edit Track(s)</button>
 </form>

--- a/src/songripper/worker.py
+++ b/src/songripper/worker.py
@@ -113,12 +113,15 @@ def mp3_from_url(url: str, staging_dir: Path):
                 cover = fetch_thumbnail(thumb_url)
         if cover:
             tags = ID3(mp3_path)
-            tags["APIC"] = APIC(
-                encoding=3,
-                mime="image/jpeg",
-                type=3,
-                desc=u"Cover",
-                data=cover,
+            tags.delall("APIC")
+            tags.add(
+                APIC(
+                    encoding=3,
+                    mime="image/jpeg",
+                    type=3,
+                    desc=u"Cover",
+                    data=cover,
+                )
             )
             tags.save()
     return artist, album, mp3_path
@@ -288,3 +291,37 @@ def update_track(filepath: str, field: str, value: str) -> Path:
                 break
             parent = parent.parent
     return new_path
+
+
+def update_album_art(filepath: str, data: bytes, mime: str = "image/jpeg") -> None:
+    """Replace the album art of ``filepath`` with ``data``.
+
+    This is a no-op when tag parsing dependencies are missing.  A
+    :class:`TrackUpdateError` is raised if the file does not exist or the
+    artwork cannot be written.
+    """
+    path = Path(filepath)
+    if not path.exists():
+        raise TrackUpdateError(f"File not found: {filepath}")
+    try:  # pragma: no cover - optional dependency
+        from mutagen.id3 import ID3, APIC
+    except Exception:
+        return
+    try:
+        tags = ID3(path)
+    except Exception:
+        tags = ID3()
+    tags.delall("APIC")
+    tags.add(
+        APIC(
+            encoding=3,
+            mime=mime or "image/jpeg",
+            type=3,
+            desc="Cover",
+            data=data,
+        )
+    )
+    try:
+        tags.save(path)
+    except Exception as e:  # pragma: no cover - unexpected failure
+        raise TrackUpdateError(str(e))


### PR DESCRIPTION
## Summary
- allow uploading album art through multi-edit form
- support saving new art on selected tracks
- expose `update_album_art` in worker
- cover album art changes with tests
- fix album art updates by using `delall()`/`add()` when writing tags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685de0e82604832ca9d23998e71e8d6a