### PR TITLE
Fix album art update

### DIFF
--- a/src/songripper/templates/staging.html
+++ b/src/songripper/templates/staging.html
@@ -32,7 +32,7 @@
 <form id="multi-edit" hx-post="/edit-multiple" hx-swap="none"
       hx-include="[name=track]:checked"
       hx-on:afterRequest="document.body.dispatchEvent(new Event('refreshStaging'))"
-      enctype="multipart/form-data">
+      enctype="multipart/form-data" hx-encoding="multipart/form-data">
   <fieldset class="edit-fields">
     <div>
       <label><input type="checkbox" name="artist_enable"> Artist</label>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -224,6 +224,15 @@ def test_staging_template_has_album_art_field():
     assert 'name="art_enable"' in html
 
 
+def test_staging_template_uses_multipart_encoding():
+    path = os.path.join(
+        os.path.dirname(__file__), "..", "src", "songripper", "templates", "staging.html"
+    )
+    with open(path) as fh:
+        html = fh.read()
+    assert 'hx-encoding="multipart/form-data"' in html
+
+
 def test_staging_template_has_select_all_checkbox():
     path = os.path.join(
         os.path.dirname(__file__), "..", "src", "songripper", "templates", "staging.html"


### PR DESCRIPTION
## Summary
- send multipart data when editing album art
- test for HX encoding attribute in staging template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685deb489778832cb4e7ef673fb0b68f