### PR TITLE
Fix Approve button with htmx requests

### DIFF
--- a/src/songripper/api.py
+++ b/src/songripper/api.py
@@ -46,8 +46,10 @@ def rip(request: Request, playlist_url: str = Form(...)):
     return RedirectResponse("/", status_code=303)
 
 @app.post("/approve")
-def approve():
-    approve_all()
+def approve(request: Request):
+    worker.approve_all()
+    if request.headers.get("Hx-Request"):
+        return HTMLResponse("", status_code=204, headers={"HX-Trigger": "refreshStaging"})
     return RedirectResponse("/", status_code=303)
 
 @app.post("/delete")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -113,6 +113,24 @@ def test_delete_non_hx_redirect(monkeypatch):
     assert resp.headers["location"] == "/?msg=Files+deleted"
 
 
+def test_approve_hx_triggers_refresh(monkeypatch):
+    monkeypatch.setattr(worker, "approve_all", lambda: None)
+    monkeypatch.setattr(api, "approve_all", lambda: None)
+    req = types.SimpleNamespace(headers={"Hx-Request": "1"})
+    resp = api.approve(req)
+    assert resp.status_code == 204
+    assert resp.headers["HX-Trigger"] == "refreshStaging"
+
+
+def test_approve_non_hx_redirect(monkeypatch):
+    monkeypatch.setattr(worker, "approve_all", lambda: None)
+    monkeypatch.setattr(api, "approve_all", lambda: None)
+    req = types.SimpleNamespace(headers={})
+    resp = api.approve(req)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/"
+
+
 def test_rip_form_has_afterrequest_handler():
     template_path = os.path.join(os.path.dirname(__file__), "..", "src", "songripper", "templates", "index.html")
     with open(template_path) as fh:


### PR DESCRIPTION
## Summary
- call worker.approve_all() in the approve route
- patch `api.approve_all` in tests to avoid touching the filesystem

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e08ebdc8c832c8c7f54640bb00b0c