### PR TITLE
Merge staged albums into existing artist folder

### DIFF
--- a/src/songripper/worker.py
+++ b/src/songripper/worker.py
@@ -148,8 +148,21 @@ def approve_all():
     # Staging may be missing if no playlists were ripped yet
     if not staging_has_files():
         return
-    for p in staging.iterdir():
-        shutil.move(str(p), NAS_PATH / p.name)
+    for p in list(staging.iterdir()):
+        dest_artist = NAS_PATH / p.name
+        if dest_artist.exists():
+            for album in p.iterdir():
+                shutil.move(str(album), dest_artist / album.name)
+            try:
+                p.rmdir()
+            except OSError:
+                pass
+        else:
+            shutil.move(str(p), dest_artist)
+    try:
+        staging.rmdir()
+    except OSError:
+        pass
 
 def delete_staging() -> bool:
     """Delete the staging directory if it contains files.

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -326,3 +326,23 @@ def test_update_album_art_missing_file_raises(tmp_path):
     with pytest.raises(worker.TrackUpdateError):
         worker.update_album_art(str(missing), b"img")
 
+
+def test_approve_all_merges_existing_artist(tmp_path):
+    worker.DATA_DIR = tmp_path
+    worker.NAS_PATH = tmp_path / "nas"
+
+    staging = tmp_path / "staging" / "Artist" / "NewAlbum"
+    staging.mkdir(parents=True)
+    (staging / "track.mp3").write_text("x")
+
+    existing = worker.NAS_PATH / "Artist" / "OldAlbum"
+    existing.mkdir(parents=True, exist_ok=True)
+    (existing / "old.mp3").write_text("y")
+
+    worker.approve_all()
+
+    assert (existing / "old.mp3").exists()
+    assert (worker.NAS_PATH / "Artist" / "NewAlbum" / "track.mp3").exists()
+    assert not (worker.NAS_PATH / "Artist" / "Artist").exists()
+    assert worker.staging_has_files() is False
+


### PR DESCRIPTION
## Summary
- move staged albums into existing NAS artist folder
- ensure staging directories are cleaned up
- test approve_all merging behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e7cf34c3c832ca78c964cc1715706