### PR TITLE
Add smooth scroll to visible errors

### DIFF
--- a/src/songripper/static/main.js
+++ b/src/songripper/static/main.js
@@ -20,10 +20,14 @@ document.addEventListener('htmx:responseError', function (evt) {
   const alerts = document.getElementById('alerts');
   if (!alerts) return;
   alerts.innerHTML = evt.detail.xhr.responseText;
+  alerts.scrollIntoView({behavior: 'smooth'});
   fadeOutAlerts(alerts);
 });
 
 document.addEventListener('htmx:afterSwap', function (evt) {
+  if (evt.detail && evt.detail.xhr && evt.detail.xhr.status >= 400) {
+    evt.target.scrollIntoView({behavior: 'smooth'});
+  }
   if (evt.target.id === 'alerts') {
     fadeOutAlerts(evt.target);
   }


### PR DESCRIPTION
## Summary
- scroll to alerts element when an HTMX request fails
- ensure swapped error content is scrolled into view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e9b260a80832c94c130082d1f80a7