### PR TITLE
Add loading indicator for track list

### DIFF
--- a/src/songripper/static/styles.css
+++ b/src/songripper/static/styles.css
@@ -78,6 +78,23 @@ footer {
   display: inline-block;
 }
 
+#list-spinner {
+  display: none;
+  width: 16px;
+  height: 16px;
+  border: 2px solid #ccc;
+  border-top-color: #333;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 1em 0;
+}
+
+#list-spinner.htmx-request {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 @keyframes spin {
   to { transform: rotate(360deg); }
 }

--- a/src/songripper/templates/index.html
+++ b/src/songripper/templates/index.html
@@ -23,7 +23,8 @@
 </form>
 
 <p>Staged files live in <code>./data/staging/</code> until you approve.</p>
-  <div id="staging-list" hx-get="/staging" hx-trigger="load, refreshStaging from:body"></div>
+  <div id="list-spinner" aria-hidden="true"></div>
+  <div id="staging-list" hx-get="/staging" hx-trigger="load, refreshStaging from:body" hx-indicator="#list-spinner"></div>
   <h3>How to Use</h3>
   <ol>
     <li>Paste a YouTube playlist URL in the field above and click <strong>Rip!</strong>.</li>


### PR DESCRIPTION
## Summary
- add spinner element for track list
- show spinner while staging list loads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f537f6c0832c8592aed7ab8f0d4a