### PR TITLE
Sort staged tracks alphabetically

### DIFF
--- a/src/songripper/worker.py
+++ b/src/songripper/worker.py
@@ -234,7 +234,7 @@ def list_staged_tracks() -> list[Track]:
                         cover=cover_b64,
                     )
                 )
-
+    tracks.sort(key=lambda t: (t.artist.lower(), t.album.lower()))
     return tracks
 
 def read_tags(filepath: str) -> dict[str, str]:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -121,18 +121,19 @@ def test_staging_has_files(tmp_path):
 def test_list_staged_tracks(tmp_path):
     worker.DATA_DIR = tmp_path
     staging = tmp_path / "staging"
-    (staging / "Artist1" / "Album1").mkdir(parents=True)
-    f1 = staging / "Artist1" / "Album1" / "Song1.mp3"
-    f1.write_text("x")
-    (staging / "Artist2" / "Album2").mkdir(parents=True)
-    f2 = staging / "Artist2" / "Album2" / "Song2.mp3"
+    # Create files in reverse order to ensure sorting occurs
+    (staging / "BArtist" / "BAlbum").mkdir(parents=True)
+    f2 = staging / "BArtist" / "BAlbum" / "Song2.mp3"
     f2.write_text("y")
+    (staging / "AArtist" / "AAlbum").mkdir(parents=True)
+    f1 = staging / "AArtist" / "AAlbum" / "Song1.mp3"
+    f1.write_text("x")
 
-    tracks = sorted(worker.list_staged_tracks(), key=lambda t: t.title)
+    tracks = worker.list_staged_tracks()
 
     assert [(t.artist, t.album, t.title, t.filepath) for t in tracks] == [
-        ("Artist1", "Album1", "Song1", str(f1)),
-        ("Artist2", "Album2", "Song2", str(f2)),
+        ("AArtist", "AAlbum", "Song1", str(f1)),
+        ("BArtist", "BAlbum", "Song2", str(f2)),
     ]
 
 


### PR DESCRIPTION
## Summary
- sort `list_staged_tracks` results by artist then album
- verify ordering in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862cfa71c68832c803c1b5ed1c766bf