### PR TITLE
Improve metadata sanitization

### DIFF
--- a/src/songripper/worker.py
+++ b/src/songripper/worker.py
@@ -16,8 +16,27 @@ YT_BASE = ["yt-dlp", "--quiet", "--no-warnings"]
 # Lock used to protect tagging operations when ripping songs concurrently
 TAG_LOCK = threading.Lock()
 
+EMOJI_RE = re.compile(
+    "["
+    "\U0001F600-\U0001F64F"  # emoticons
+    "\U0001F300-\U0001F5FF"  # symbols & pictographs
+    "\U0001F680-\U0001F6FF"  # transport & map symbols
+    "\U0001F1E0-\U0001F1FF"  # flags
+    "\U00002700-\U000027BF"  # dingbats
+    "\U0001F900-\U0001F9FF"  # supplemental symbols
+    "\U0001FA70-\U0001FAFF"  # symbols & pictographs extended-A
+    "\U00002600-\U000026FF"  # misc symbols
+    "\U000024C2-\U0001F251"  # enclosed characters
+    "]",
+    flags=re.UNICODE,
+)
+
 def clean(text: str) -> str:
-    return re.sub(r'[\\/*?:"<>|]', "_", text).strip()
+    """Return ``text`` safe for use in file paths."""
+    text = re.sub(r'[\\/*?:"<>|]', " ", text)
+    text = EMOJI_RE.sub(" ", text)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
 
 def fetch_cover(artist: str, title: str, requests_mod=None) -> bytes | None:
     """Return album art from iTunes if available.

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -10,9 +10,14 @@ from songripper.worker import clean, fetch_cover, delete_staging
 import pytest
 
 
-def test_clean_removes_forbidden_chars():
+def test_clean_replaces_forbidden_chars_with_space():
     text = 'A/B:C*D?E"F<G>H|I'
-    assert clean(text) == 'A_B_C_D_E_F_G_H_I'
+    assert clean(text) == 'A B C D E F G H I'
+
+
+def test_clean_removes_emojis_and_collapses_space():
+    text = 'Hello\U0001F600 World \U0001F3B5'
+    assert clean(text) == 'Hello World'
 
 
 def test_fetch_cover_uses_requests_module():


### PR DESCRIPTION
## Summary
- sanitize emoji and replace invalid filename characters with spaces
- ensure spaces collapse to single separators
- test replacement logic for symbols and emoji

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863cfbdf890832cb0dbb30c7a5d329d