### PR TITLE
Add default metadata fallback when cleaning

### DIFF
--- a/src/songripper/worker.py
+++ b/src/songripper/worker.py
@@ -98,6 +98,13 @@ def mp3_from_url(url: str, staging_dir: Path, lock: threading.Lock = TAG_LOCK):
     artist = clean(meta.get("artist") or meta["uploader"])
     title = clean(meta.get("track") or meta["title"])
     album = clean(meta.get("album") or meta.get("playlist") or "Singles")
+
+    if not artist:
+        artist = "Unknown Artist"
+    if not album:
+        album = "Unknown Album"
+    if not title:
+        title = "Unknown Title"
     track_no = meta.get("track_number")
     prefix = ""
     if track_no:


### PR DESCRIPTION
## Summary
- default cleaned `artist`, `album`, and `title` to "Unknown" values when empty
- test `mp3_from_url` with emoji-only metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686445db8610832c97c4238a65b60d65