### PR TITLE
Fix look online button disabled until track selected

### DIFF
--- a/src/songripper/static/main.js
+++ b/src/songripper/static/main.js
@@ -81,6 +81,8 @@ function handleAlbumArtClick(e) {
   if (!form) return;
   const section = document.getElementById('online-art');
   if (section) section.hidden = false;
+  const lookBtn = form.querySelector('#look-online-btn');
+  if (lookBtn) lookBtn.disabled = false;
   const artistField = form.querySelector('#online-art input[name="artist"]');
   const albumField = form.querySelector('#online-art input[name="album"]');
   const fileField = form.querySelector('#online-art input[name="filepath"]');

--- a/src/songripper/templates/staging.html
+++ b/src/songripper/templates/staging.html
@@ -52,7 +52,7 @@
     <input type="hidden" name="artist">
     <input type="hidden" name="album">
     <input type="hidden" name="filepath">
-    <button type="button" id="look-online-btn" hx-get="/search-art" hx-target="#art-results" hx-include="#online-art input">Look online</button>
+    <button type="button" id="look-online-btn" hx-get="/search-art" hx-target="#art-results" hx-include="#online-art input" disabled>Look online</button>
     <div id="art-results"></div>
   </div>
   <button type="submit">Edit Track(s)</button>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -294,4 +294,6 @@ def test_staging_template_has_online_art_section():
         html = fh.read()
     assert 'id="online-art"' in html
     assert 'hx-get="/search-art"' in html
+    assert 'id="look-online-btn"' in html
+    assert 'look-online-btn" hx-get="/search-art" hx-target="#art-results" hx-include="#online-art input" disabled' in html
     assert 'data-filepath' in html


### PR DESCRIPTION
## Summary
- disable Look online button until a track's album art is clicked
- enable button in JavaScript when fields populate
- update test for new default state

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68647e84ac58832c9a72c59510753d44