### PR TITLE
Fix album art edit error

### DIFF
--- a/src/songripper/static/main.js
+++ b/src/songripper/static/main.js
@@ -41,12 +41,12 @@ document.addEventListener('htmx:afterSwap', function (evt) {
 function updateApprovalButton() {
   const btnAll = document.getElementById('approve-btn');
   const btnSel = document.getElementById('approve-selected-btn');
+  const editBtn = document.querySelector('#multi-edit button[type=submit]');
   const hasTracks = document.querySelector('#staging-list tbody tr') !== null;
   if (btnAll) btnAll.disabled = !hasTracks;
-  if (btnSel) {
-    const anyChecked = document.querySelector('#staging-list input[name=track]:checked') !== null;
-    btnSel.disabled = !anyChecked;
-  }
+  const anyChecked = document.querySelector('#staging-list input[name=track]:checked') !== null;
+  if (btnSel) btnSel.disabled = !anyChecked;
+  if (editBtn) editBtn.disabled = !anyChecked;
 }
 
 function fillMultiEditFromCell(e) {

--- a/src/songripper/templates/staging.html
+++ b/src/songripper/templates/staging.html
@@ -47,7 +47,7 @@
       <label><input type="checkbox" name="art_enable"> Album Art</label>
       <input type="file" name="art_file" accept="image/*"></div>
   </fieldset>
-  <button type="submit">Edit Track(s)</button>
+  <button id="edit-btn" type="submit"{% if not tracks %} disabled{% endif %}>Edit Track(s)</button>
 </form>
 {% else %}
 <p id="no-tracks">No tracks found</p>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -213,6 +213,7 @@ def test_staging_template_has_multi_edit_form():
         html = fh.read()
     assert "Edit Track(s)" in html
     assert "hx-post=\"/edit-multiple\"" in html
+    assert 'id="edit-btn"' in html
 
 
 def test_staging_template_has_album_art_field():


### PR DESCRIPTION
## Summary
- disable Edit Track(s) button until at least one track is selected
- keep button disabled when there are no staged tracks
- test template for new `edit-btn` id

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686496b6be3c832c8edda8dd7d4d8d93