### PR TITLE
Switch to m4a audio output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SongRipper
 
-SongRipper is a small FastAPI service that converts YouTube playlists or single videos into tagged MP3 files.
+SongRipper is a small FastAPI service that converts YouTube playlists or single videos into tagged M4A files.
 It downloads each video, extracts the audio, fetches metadata such as artist, title and album
-information and writes ID3 tags with cover art.  Tracks are placed in a staging directory until
+information and writes tags with cover art.  Tracks are placed in a staging directory until
 approved, after which they are moved to the final music library.
 
 ## Running with Docker

--- a/src/songripper/worker.py
+++ b/src/songripper/worker.py
@@ -22,6 +22,8 @@ ALBUM_ART_CACHE = _service.album_art_cache
 ALBUM_LOCK = _service.album_lock
 DATA_DIR = _service.data_dir
 NAS_PATH = _service.nas_path
+AUDIO_FORMAT = RipperService.AUDIO_FORMAT
+AUDIO_EXT = RipperService.AUDIO_EXT
 
 
 def _sync_service() -> None:


### PR DESCRIPTION
## Summary
- upgrade ripping to M4A audio with AAC codec
- keep tag writing and cover art support using MP4 tags
- document new default format
- update tests for the new format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865c8240820832c8a8a9b2ded96e6d3