### PR TITLE
Add duplicate check approval workflow

### DIFF
--- a/src/songripper/worker.py
+++ b/src/songripper/worker.py
@@ -92,6 +92,12 @@ def approve_selected(paths: list[str]) -> None:
     _service.approve_selected(paths, shutil_mod=shutil)
 
 
+def approve_with_checks(input_func=input) -> None:
+    """Approve all staged tracks with duplicate checks."""
+    _sync_service()
+    _service.approve_with_checks(shutil_mod=shutil, input_func=input_func)
+
+
 def delete_staging() -> bool:
     _sync_service()
     return _service.delete_staging(shutil_mod=shutil)


### PR DESCRIPTION
## Summary
- implement `approve_with_checks` for duplicate-aware file moves
- expose new workflow through worker interface
- test overwrite and skip behaviour during approval

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865ed9c9ccc832c9961446b03181f36